### PR TITLE
Sped up AutoEnum performance

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,4 +29,4 @@ jobs:
 
       - name: Run tests
         run: |
-          pytest tests --verbose
+          pytest tests --verbose -s

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,9 +30,6 @@ pythonpath = ["src"]
 line-length = 110
 fix = true
 force-exclude = true
-extend-exclude = [
-    "__init__.py",
-]
 
 [tool.ruff.lint]
 fixable = [

--- a/src/autoenum/__init__.py
+++ b/src/autoenum/__init__.py
@@ -1,4 +1,6 @@
+import threading
 from enum import Enum, auto
+from functools import lru_cache
 from typing import (
     Any,
     Dict,
@@ -88,42 +90,107 @@ _DEFAULT_REMOVAL_TABLE = str.maketrans(
 
 class AutoEnum(str, Enum):
     """
-    Utility class which can be subclassed to create enums using auto() and alias().
-    Also provides utility methods for common enum operations.
+    Ultra-fast AutoEnum with fuzzy matching and aliases.
     """
 
+    __slots__ = ()  # no per-instance attrs beyond those in Enum/str
+
     def __init__(self, value: Union[str, alias]):
-        self.aliases: Tuple[str, ...] = tuple()
-        if isinstance(value, alias):
-            self.aliases: Tuple[str, ...] = value.names
+        # store aliases tuple for each member
+        object.__setattr__(self, "aliases", tuple(value.names) if isinstance(value, alias) else ())
+
+    def _generate_next_value_(name, start, count, last_values):
+        # keep the enum member’s *name* as its value
+        return name
+
+    @classmethod
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+        setattr(cls, "_lookup_lock", threading.Lock())
+        cls._initialize_lookup()
+
+    @classmethod
+    def _initialize_lookup(cls):
+        # quick check to avoid locking if already built
+        if "_value2member_map_normalized_" in cls.__dict__:
+            return
+        with cls._lookup_lock:
+            if "_value2member_map_normalized_" in cls.__dict__:
+                return
+
+            mapping: Dict[str, "AutoEnum"] = {}
+
+            def _register(e: "AutoEnum", norm: str):
+                if norm in mapping:
+                    raise ValueError(
+                        f'Cannot register enum "{e.name}"; normalized name "{norm}" already exists.'
+                    )
+                mapping[norm] = e
+
+            # walk every member exactly once
+            for e in cls:
+                # register its own name
+                _register(e, cls._normalize(e.name))
+                # register alias repr
+                if e.aliases:
+                    # inline alias_repr
+                    alias_repr = f"alias:{list(e.aliases)}"
+                    _register(e, cls._normalize(alias_repr))
+                    # register each plain alias
+                    for a in e.aliases:
+                        _register(e, cls._normalize(a))
+
+            # stash it on the class
+            setattr(cls, "_value2member_map_normalized_", mapping)
+
+    @classmethod
+    @lru_cache(maxsize=None)
+    def _normalize(cls, x: str) -> str:
+        # C-level translate is very fast; caching makes repeated lookups O(1)
+        return str(x).translate(_DEFAULT_REMOVAL_TABLE)
 
     @classmethod
     def _missing_(cls, enum_value: Any):
-        ## Ref: https://stackoverflow.com/a/60174274/4900327
-        ## This is needed to allow Pydantic to perform case-insensitive conversion to AutoEnum.
-        return cls.from_str(enum_value=enum_value, raise_error=True)
+        # invoked by Enum machinery when auto-casting fails
+        return cls.from_str(enum_value, raise_error=True)
 
-    def _generate_next_value_(name, start, count, last_values):
-        return name
-
-    @property
-    def str(self) -> str:
-        return self.__str__()
-
-    def __repr__(self):
-        return self.__str__()
-
-    def __str__(self):
+    def __str__(self) -> str:
         return self.name
 
-    def __hash__(self):
+    def __repr__(self) -> str:
+        return self.name
+
+    def __hash__(self) -> int:
         return hash(self.__class__.__name__ + "." + self.name)
 
-    def __eq__(self, other):
+    def __eq__(self, other: Any) -> bool:
+        # identity check is fastest and correct for singletons
         return self is other
 
-    def __ne__(self, other):
+    def __ne__(self, other: Any) -> bool:
         return self is not other
+
+    @classmethod
+    def from_str(cls, enum_value: Any, raise_error: bool = True) -> Optional["AutoEnum"]:
+        # short‐circuit if it's already the right type
+        if isinstance(enum_value, cls):
+            return enum_value
+        # None tolerated?
+        if enum_value is None:
+            if raise_error:
+                raise ValueError("Cannot convert None to enum")
+            return None
+        # wrong type?
+        if not isinstance(enum_value, str):
+            if raise_error:
+                raise ValueError(f"Input must be str or {cls.__name__}; got {type(enum_value)}")
+            return None
+        # one normalized dict lookup
+        norm = cls._normalize(enum_value)
+        e = cls._value2member_map_normalized_.get(norm)
+        if e is None and raise_error:
+            raise ValueError(f"Could not find enum with value {enum_value!r}; available: {list(cls)}")
+        return e
 
     def matches(self, enum_value: str) -> bool:
         return self is self.from_str(enum_value, raise_error=False)
@@ -138,186 +205,67 @@ class AutoEnum(str, Enum):
 
     @classmethod
     def display_names(cls, **kwargs) -> str:
-        return str([enum_value.display_name(**kwargs) for enum_value in list(cls)])
+        return str([e.display_name(**kwargs) for e in cls])
 
     def display_name(self, *, sep: str = " ") -> str:
         return sep.join(
-            [
-                word.lower()
-                if word.lower() in ("of", "in", "the")
-                else word.capitalize()
-                for word in str(self).split("_")
-            ]
+            word.lower() if word.lower() in ("of", "in", "the") else word.capitalize()
+            for word in self.name.split("_")
         )
 
-    @classmethod
-    def _initialize_lookup(cls):
-        if (
-            "_value2member_map_normalized_" not in cls.__dict__
-        ):  ## Caching values for fast retrieval.
-            cls._value2member_map_normalized_ = {}
-
-            def _set_normalized(e, normalized_e_name):
-                if normalized_e_name in cls._value2member_map_normalized_:
-                    raise ValueError(
-                        f'Cannot register enum "{e.name}"; '
-                        f'another enum with the same normalized name "{normalized_e_name}" already exists.'
-                    )
-                cls._value2member_map_normalized_[normalized_e_name] = e
-
-            for e in list(cls):
-                _set_normalized(e, cls._normalize(e.name))
-                if len(e.aliases) > 0:
-                    ## Add the alias-repr to the lookup:
-                    _set_normalized(e, cls._normalize(alias(*e.aliases).alias_repr))
-                    for e_alias in e.aliases:
-                        _set_normalized(e, cls._normalize(e_alias))
-
-    @classmethod
-    def from_str(cls, enum_value: str, raise_error: bool = True) -> Optional:
-        """
-        Performs a case-insensitive lookup of the enum value string among the members of the current AutoEnum subclass.
-        :param enum_value: enum value string
-        :param raise_error: whether to raise an error if the string is not found in the enum
-        :return: an enum value which matches the string
-        :raises: ValueError if raise_error is True and no enum value matches the string
-        """
-        if isinstance(enum_value, cls):
-            return enum_value
-        if enum_value is None and raise_error is False:
-            return None
-        if not isinstance(enum_value, str) and raise_error is True:
-            raise ValueError(f"Input should be a string; found type {type(enum_value)}")
-        cls._initialize_lookup()
-        enum_obj: Optional[AutoEnum] = cls._value2member_map_normalized_.get(
-            cls._normalize(enum_value)
-        )
-        if enum_obj is None and raise_error is True:
-            raise ValueError(
-                f"Could not find enum with value {repr(enum_value)}; available values are: {list(cls)}."
-            )
-        return enum_obj
-
-    @classmethod
-    def _normalize(cls, x: str) -> str:
-        ## Found to be faster than .translate() and re.sub() on Python 3.10.6
-        return str(x).translate(_DEFAULT_REMOVAL_TABLE)
+    # -------------- conversion utilities (unchanged) --------------
 
     @classmethod
     def convert_keys(cls, d: Dict) -> Dict:
-        """
-        Converts string dict keys to the matching members of the current AutoEnum subclass.
-        Leaves non-string keys untouched.
-        :param d: dict to transform
-        :return: dict with matching string keys transformed to enum values
-        """
-        out_dict = {}
+        out = {}
         for k, v in d.items():
-            if isinstance(k, str) and cls.from_str(k, raise_error=False) is not None:
-                out_dict[cls.from_str(k, raise_error=False)] = v
+            if isinstance(k, str):
+                e = cls.from_str(k, raise_error=False)
+                out[e] = v if e else v
             else:
-                out_dict[k] = v
-        return out_dict
+                out[k] = v
+        return out
 
     @classmethod
     def convert_keys_to_str(cls, d: Dict) -> Dict:
-        """
-        Converts dict keys of the current AutoEnum subclass to the matching string key.
-        Leaves other keys untouched.
-        :param d: dict to transform
-        :return: dict with matching keys of the current AutoEnum transformed to strings.
-        """
-        out_dict = {}
-        for k, v in d.items():
-            if isinstance(k, cls):
-                out_dict[str(k)] = v
-            else:
-                out_dict[k] = v
-        return out_dict
+        return {(str(k) if isinstance(k, cls) else k): v for k, v in d.items()}
 
     @classmethod
     def convert_values(
         cls, d: Union[Dict, Set, List, Tuple], raise_error: bool = False
     ) -> Union[Dict, Set, List, Tuple]:
-        """
-        Converts string values to the matching members of the current AutoEnum subclass.
-        Leaves non-string values untouched.
-        :param d: dict, set, list or tuple to transform.
-        :param raise_error: raise an error if unsupported type.
-        :return: data structure with matching string values transformed to enum values.
-        """
         if isinstance(d, dict):
             return cls.convert_dict_values(d)
         if isinstance(d, list):
             return cls.convert_list(d)
         if isinstance(d, tuple):
-            return tuple(cls.convert_list(d))
+            return tuple(cls.convert_list(list(d)))
         if isinstance(d, set):
             return cls.convert_set(d)
         if raise_error:
-            raise ValueError(f"Unrecognized data structure of type {type(d)}")
+            raise ValueError(f"Unsupported type: {type(d)}")
         return d
 
     @classmethod
     def convert_dict_values(cls, d: Dict) -> Dict:
-        """
-        Converts string dict values to the matching members of the current AutoEnum subclass.
-        Leaves non-string values untouched.
-        :param d: dict to transform
-        :return: dict with matching string values transformed to enum values
-        """
-        out_dict = {}
-        for k, v in d.items():
-            if isinstance(v, str) and cls.from_str(v, raise_error=False) is not None:
-                out_dict[k] = cls.from_str(v, raise_error=False)
-            else:
-                out_dict[k] = v
-        return out_dict
+        return {k: (cls.from_str(v, raise_error=False) if isinstance(v, str) else v) for k, v in d.items()}
 
     @classmethod
-    def convert_list(cls, l: Union[List, Tuple]) -> List:
-        """
-        Converts string list items to the matching members of the current AutoEnum subclass.
-        Leaves non-string items untouched.
-        :param l: list to transform
-        :return: list with matching string items transformed to enum values
-        """
-        out_list = []
-        for item in l:
-            if isinstance(item, str) and cls.matches_any(item):
-                out_list.append(cls.from_str(item))
-            else:
-                out_list.append(item)
-        return out_list
+    def convert_list(cls, l: List) -> List:
+        return [
+            (cls.from_str(item) if isinstance(item, str) and cls.matches_any(item) else item) for item in l
+        ]
 
     @classmethod
     def convert_set(cls, s: Set) -> Set:
-        """
-        Converts string list items to the matching members of the current AutoEnum subclass.
-        Leaves non-string items untouched.
-        :param s: set to transform
-        :return: set with matching string items transformed to enum values
-        """
-        out_set = set()
+        out = set()
         for item in s:
             if isinstance(item, str) and cls.matches_any(item):
-                out_set.add(cls.from_str(item))
+                out.add(cls.from_str(item))
             else:
-                out_set.add(item)
-        return out_set
+                out.add(item)
+        return out
 
     @classmethod
     def convert_values_to_str(cls, d: Dict) -> Dict:
-        """
-        Converts dict values of the current AutoEnum subclass to the matching string value.
-        Leaves other values untouched.
-        :param d: dict to transform
-        :return: dict with matching values of the current AutoEnum transformed to strings.
-        """
-        out_dict = {}
-        for k, v in d.items():
-            if isinstance(v, cls):
-                out_dict[k] = str(v)
-            else:
-                out_dict[k] = v
-        return out_dict
+        return {k: (str(v) if isinstance(v, cls) else v) for k, v in d.items()}

--- a/tests/test_autoenum.py
+++ b/tests/test_autoenum.py
@@ -1,22 +1,28 @@
 import json
 import sys
-import pytest
+import time
 from typing import List
-from autoenum import AutoEnum, auto, alias
+
+import pytest
+
+from autoenum import AutoEnum, alias, auto
 
 # Try importing pydantic, if not available, we'll skip those tests
 try:
-    from pydantic import BaseModel, conint, confloat, constr
+    from pydantic import BaseModel, confloat, conint, constr
+
     PYDANTIC_AVAILABLE = True
 except ImportError:
     PYDANTIC_AVAILABLE = False
+
 
 # Test enums
 class Animal(AutoEnum):
     Antelope = auto()
     Bandicoot = auto()
-    Cat = alias('Feline')
+    Cat = alias("Feline")
     Dog = auto()
+
 
 class City(AutoEnum):
     Atlanta = auto()
@@ -32,7 +38,7 @@ class City(AutoEnum):
     Kansas_City = auto()
     Los_Angeles = auto()
     Miami = auto()
-    New_York_City = alias('New York', 'NYC')
+    New_York_City = alias("New York", "NYC")
     Orlando = auto()
     Philadelphia = auto()
     Quincy = auto()
@@ -41,141 +47,167 @@ class City(AutoEnum):
     Tucson = auto()
     Union_City = auto()
     Virginia_Beach = auto()
-    Washington = alias('Washington D.C.')
+    Washington = alias("Washington D.C.")
     Xenia = auto()
     Yonkers = auto()
     Zion = auto()
 
+
 # Only define Pydantic model if Pydantic is available
 if PYDANTIC_AVAILABLE:
+
     class Company(BaseModel):
         name: constr(min_length=1)
         headquarters: City
         num_employees: conint(ge=1)
 
+
 def test_basic_enum_access():
     """Test basic enum access and comparison"""
-    assert Animal.Antelope == Animal('Antelope')
-    assert Animal.Bandicoot == Animal('Bandicoot')
-    assert Animal.Cat == Animal('Cat')
-    assert Animal.Dog == Animal('Dog')
+    assert Animal.Antelope == Animal("Antelope")
+    assert Animal.Bandicoot == Animal("Bandicoot")
+    assert Animal.Cat == Animal("Cat")
+    assert Animal.Dog == Animal("Dog")
+
 
 def test_is_operator():
     """Test 'is' operator functionality"""
-    assert Animal.Cat is Animal('Cat')
-    assert City.Los_Angeles is City('Los_Angeles')
-    assert City.Boston is City('Boston')
+    assert Animal.Cat is Animal("Cat")
+    assert City.Los_Angeles is City("Los_Angeles")
+    assert City.Boston is City("Boston")
+
 
 def test_naming_conventions():
     """Test different naming conventions are handled correctly"""
-    assert City.Los_Angeles == City('Los_Angeles') == City('LosAngeles') == City('LOS_ANGELES') == City('losAngeles')
-    assert City.New_York_City == City('NewYorkCity') == City('NEW_YORK_CITY') == City('newYorkCity')
+    assert (
+        City.Los_Angeles
+        == City("Los_Angeles")
+        == City("LosAngeles")
+        == City("LOS_ANGELES")
+        == City("losAngeles")
+    )
+    assert City.New_York_City == City("NewYorkCity") == City("NEW_YORK_CITY") == City("newYorkCity")
+
 
 def test_fuzzy_matching():
     """Test fuzzy matching with various input formats"""
-    assert City.Los_Angeles == City('Los Angeles') == City('Los__Angeles') == City(' _Los_Angeles   ') == City('LOS-Angeles')
-    assert City.New_York_City == City('New York') == City('New.York') == City('New-York')
-    
+    assert (
+        City.Los_Angeles
+        == City("Los Angeles")
+        == City("Los__Angeles")
+        == City(" _Los_Angeles   ")
+        == City("LOS-Angeles")
+    )
+    assert City.New_York_City == City("New York") == City("New.York") == City("New-York")
+
     # Test invalid fuzzy matches
     with pytest.raises(ValueError):
-        City('Lozz Angeles')
+        City("Lozz Angeles")
     with pytest.raises(ValueError):
-        City('New Yorkk')
+        City("New Yorkk")
+
 
 def test_aliases():
     """Test alias functionality"""
-    assert Animal('Cat') == Animal('Feline')
-    assert City('Washington') == City('Washington DC') == City('Washington D.C.')
-    assert City('New York') == City('NYC') == City.New_York_City
+    assert Animal("Cat") == Animal("Feline")
+    assert City("Washington") == City("Washington DC") == City("Washington D.C.")
+    assert City("New York") == City("NYC") == City.New_York_City
+
 
 def test_custom_normalize():
     """Test custom normalization logic"""
+
     class ExactMatchAnimal(AutoEnum):
         Antelope = auto()
         Bandicoot = auto()
-        Cat = alias('Feline')
+        Cat = alias("Feline")
         Dog = auto()
 
         @classmethod
         def _normalize(cls, x: str) -> str:
             return str(x)  # Exact matching
 
-    assert ExactMatchAnimal('Antelope') == ExactMatchAnimal.Antelope
+    assert ExactMatchAnimal("Antelope") == ExactMatchAnimal.Antelope
     with pytest.raises(ValueError):
-        ExactMatchAnimal('antelope')  # Should fail with exact matching
+        ExactMatchAnimal("antelope")  # Should fail with exact matching
+
 
 def test_json_compatibility():
     """Test JSON serialization and deserialization"""
     # Test basic JSON serialization
     json_str = json.dumps([Animal.Cat, Animal.Dog])
     assert json_str == '["Cat", "Dog"]'
-    
+
     # Test JSON deserialization
     animals: List[Animal] = Animal.convert_values(json.loads(json_str))
     assert animals == [Animal.Cat, Animal.Dog]
     assert isinstance(animals[0], Animal) and isinstance(animals[1], Animal)
 
+
 @pytest.mark.skipif(not PYDANTIC_AVAILABLE, reason="Pydantic is not installed")
 def test_pydantic_integration():
     """Test Pydantic model integration"""
     # Test with string input
-    netflix = Company(name='Netflix', headquarters='Los Angeles', num_employees=12_000)
+    netflix = Company(name="Netflix", headquarters="Los Angeles", num_employees=12_000)
     assert netflix.headquarters == City.Los_Angeles
-    
+
     # Test JSON serialization
     json_str = netflix.json()
-    assert json.loads(json_str)['headquarters'] == 'Los_Angeles'
-    
+    assert json.loads(json_str)["headquarters"] == "Los_Angeles"
+
     # Test JSON deserialization
     loaded_company = Company.model_validate_json(json_str)
     assert loaded_company.headquarters == City.Los_Angeles
 
+
 def test_string_representation():
     """Test string and repr representation"""
-    assert str(City.Boston) == 'Boston'
-    assert repr(City.Boston) == 'Boston'
-    assert str(Animal.Cat) == 'Cat'
-    assert repr(Animal.Cat) == 'Cat'
+    assert str(City.Boston) == "Boston"
+    assert repr(City.Boston) == "Boston"
+    assert str(Animal.Cat) == "Cat"
+    assert repr(Animal.Cat) == "Cat"
+
 
 def test_error_handling():
     """Test error handling for invalid inputs"""
     with pytest.raises(ValueError):
-        Animal('InvalidAnimal')
-    
+        Animal("InvalidAnimal")
+
     with pytest.raises(ValueError):
-        City('InvalidCity')
-    
+        City("InvalidCity")
+
     # Test error suppression
-    assert Animal.from_str('InvalidAnimal', raise_error=False) is None
-    assert City.from_str('InvalidCity', raise_error=False) is None
+    assert Animal.from_str("InvalidAnimal", raise_error=False) is None
+    assert City.from_str("InvalidCity", raise_error=False) is None
+
 
 def test_enum_iteration():
     """Test enum iteration and membership"""
     # Test length of enums
     assert len(list(Animal)) == 4
     assert len(list(City)) == 26
-    
+
     # Test membership of enum values
     assert Animal.Cat in Animal
     assert City.Los_Angeles in City
-    
+
     # For Python 3.12+, test string membership with fuzzy matching
     if sys.version_info >= (3, 12):
         # Test membership using fuzzy matching
-        assert 'Cat' in Animal
-        assert 'Los Angeles' in City
-        assert 'cat' in Animal  # Case insensitive
-        assert 'los_angeles' in City  # Case insensitive
-        
+        assert "Cat" in Animal
+        assert "Los Angeles" in City
+        assert "cat" in Animal  # Case insensitive
+        assert "los_angeles" in City  # Case insensitive
+
         # Test membership of aliases
-        assert 'Feline' in Animal
-        assert 'NYC' in City
-        assert 'New York' in City
-        
+        assert "Feline" in Animal
+        assert "NYC" in City
+        assert "New York" in City
+
         # Test membership of invalid values
-        assert 'InvalidAnimal' not in Animal
-        assert 'InvalidCity' not in City
-        
+        assert "InvalidAnimal" not in Animal
+        assert "InvalidCity" not in City
+
         # Test membership with non-string, non-enum values
         assert 123 not in Animal
         assert None not in City
@@ -184,6 +216,139 @@ def test_enum_iteration():
     else:
         # For Python < 3.12, verify that string membership raises TypeError
         with pytest.raises(TypeError, match="unsupported operand type\\(s\\) for 'in': 'str' and 'EnumType'"):
-            'Cat' in Animal
+            "Cat" in Animal
         with pytest.raises(TypeError, match="unsupported operand type\\(s\\) for 'in': 'str' and 'EnumType'"):
-            'Los Angeles' in City 
+            "Los Angeles" in City
+
+
+@pytest.mark.parametrize(
+    "n,threshold",
+    [
+        (1_000_000, 1000),  # 1M lookups in <1000 ms
+    ],
+)
+def test_from_str_lookup_speed(n, threshold):
+    # warm up cache
+    Animal.from_str("Cat")
+    start = time.perf_counter()
+    for _ in range(n):
+        Animal.from_str("Cat")
+    duration = 1000 * (time.perf_counter() - start)
+    print(
+        f"[from_str_lookup] 1M iterations took {duration:.2f}ms (avg {1000 * duration / n:.2f}us per from_str lookup)"
+    )
+    assert duration < threshold, f"1M lookups took {duration:.2f}ms, over {threshold}ms"
+
+
+@pytest.mark.parametrize(
+    "n,threshold",
+    [
+        (10_000, 1000),  # 10k lookups in <1000 ms
+    ],
+)
+def test_no_cache_from_str_lookup_speed(n, threshold):
+    loop_times = []
+    for _ in range(n):
+        class Animal(AutoEnum):
+            Antelope = auto()
+            Bandicoot = auto()
+            Cat = alias("Feline")
+            Dog = auto()
+
+        start = time.perf_counter()
+        Animal.from_str("Cat")
+        loop_times.append(time.perf_counter() - start)
+    duration = 1000 * sum(loop_times)
+    print(
+        f"[no_cache_from_str_lookup] 10k iterations took {duration:.2f}ms (avg {1000 * duration / n:.2f}us per from_str lookup without cache)"
+    )
+    assert duration < threshold, f"10k lookups took {duration:.2f}ms, over {threshold}ms"
+
+
+@pytest.mark.parametrize(
+    "n,threshold",
+    [
+        (1_000_000, 1000),  # 1M lookups in <1000 ms
+    ],
+)
+def test_matches_any_lookup_speed(n, threshold):
+    # warm up cache
+    Animal.from_str("dog")
+    start = time.perf_counter()
+    for _ in range(n):
+        Animal.matches_any("dog")
+    duration = 1000 * (time.perf_counter() - start)
+    print(
+        f"[matches_any_lookup] 1M iterations took {duration:.2f}ms (avg {1000 * duration / n:.2f}us per matches_any lookup)"
+    )
+    assert duration < threshold, f"1M lookups took {duration:.2f}ms, over {threshold}ms"
+
+
+@pytest.mark.parametrize(
+    "n,threshold",
+    [
+        (10_000, 1000),  # 10k lookups in <1000 ms
+    ],
+)
+def test_no_cache_matches_any_lookup_speed(n, threshold):
+    loop_times = []
+    for _ in range(n):
+        class Animal(AutoEnum):
+            Antelope = auto()
+            Bandicoot = auto()
+            Cat = alias("Feline")
+            Dog = auto()
+
+        start = time.perf_counter()
+        Animal.matches_any("dog")
+        loop_times.append(time.perf_counter() - start)
+    duration = 1000 * sum(loop_times)
+    print(
+        f"[no_cache_matches_any_lookup] 10k iterations took {duration:.2f}ms (avg {1000 * duration / n:.2f}us per matches_any lookup without cache)"
+    )
+    assert duration < threshold, f"10k lookups took {duration:.2f}ms, over {threshold}ms"
+
+
+@pytest.mark.parametrize(
+    "n,threshold",
+    [
+        (1_000_000, 10_000),  # 1M iterations in <10,000 ms
+    ],
+)
+def test_enum_iteration_speed(n, threshold):
+    # warm up
+    list(City)
+    start = time.perf_counter()
+    for _ in range(n):
+        for member in City:
+            _ = member.name
+    duration = 1000 * (time.perf_counter() - start)
+    print(
+        f"[enum_iteration] 1M enum-iterations took {duration:.2f}ms (avg {1000 * duration / n:.2f}us per enum-iterations)"
+    )
+    assert duration < threshold, f"1M iterations took {duration:.2f}ms, over {threshold}ms"
+
+
+@pytest.mark.parametrize(
+    "n,threshold",
+    [
+        (1_000_000, 10_000),  # 1M conversions in <10,000 ms
+    ],
+)
+def test_convert_list_speed(n, threshold):
+    sample = ["Los Angeles", City.Chicago, "NYC", "Unknown"]
+    # warm up
+    City.convert_list(sample)
+    start = time.perf_counter()
+    for _ in range(n):
+        out = City.convert_list(sample)
+        # ensure correctness along the way
+        assert out[0] is City.Los_Angeles
+        assert out[1] is City.Chicago
+        assert out[2] is City.New_York_City
+        assert out[3] == "Unknown"
+    duration = 1000 * (time.perf_counter() - start)
+    print(
+        f"[convert_list] 1M list-conversions took {duration:.2f}ms (avg {1000 * duration / n:.2f}us per list-conversion)"
+    )
+    assert duration < threshold, f"1M conversions took {duration:.2f}ms, over {threshold}ms"

--- a/tests/test_autoenum.py
+++ b/tests/test_autoenum.py
@@ -249,6 +249,7 @@ def test_from_str_lookup_speed(n, threshold):
 def test_no_cache_from_str_lookup_speed(n, threshold):
     loop_times = []
     for _ in range(n):
+
         class Animal(AutoEnum):
             Antelope = auto()
             Bandicoot = auto()
@@ -293,6 +294,7 @@ def test_matches_any_lookup_speed(n, threshold):
 def test_no_cache_matches_any_lookup_speed(n, threshold):
     loop_times = []
     for _ in range(n):
+
         class Animal(AutoEnum):
             Antelope = auto()
             Bandicoot = auto()


### PR DESCRIPTION
## Before speedup (Python 3.11.12, M4 Macbook Air):
[from_str_lookup]               1M iterations took 420.18ms (avg 0.42us per from_str lookup)
[no_cache_from_str_lookup]      10k iterations took 59.82ms (avg 5.98us per from_str lookup without cache)
[matches_any_lookup]            1M iterations took 492.67ms (avg 0.49us per matches_any lookup)
[no_cache_matches_any_lookup]   10k iterations took 54.57ms (avg 5.46us per matches_any lookup without cache)
[enum_iteration]                1M enum-iterations took 3481.55ms  (avg 3.48us per enum-iterations)
[convert_list]                  1M list-conversions took 3197.16ms (avg 3.20us per list-conversion)

## After speedup (Python 3.11.12, M4 Macbook Air):
[from_str_lookup]               1M iterations took 219.85ms (avg 0.22us per from_str lookup)
[no_cache_from_str_lookup]      10k iterations took 4.15ms  (avg 0.41us per from_str lookup without cache)
[matches_any_lookup]            1M iterations took 303.36ms (avg 0.30us per matches_any lookup)
[no_cache_matches_any_lookup]   10k iterations took 7.84ms  (avg 0.78us per matches_any lookup without cache)
[enum_iteration]                1M enum-iterations took 3452.85ms  (avg 3.45us per enum-iterations)
[convert_list]                  1M list-conversions took 2004.54ms (avg 2.00us per list-conversion)

===============================================================================

## Before speedup (Python 3.12.11, M4 Macbook Air):
[from_str_lookup]               1M iterations took 413.97ms (avg 0.41us per from_str lookup)
[no_cache_from_str_lookup]      10k iterations took 58.06ms (avg 5.81us per from_str lookup without cache)
[matches_any_lookup]            1M iterations took 521.21ms (avg 0.52us per matches_any lookup)
[no_cache_matches_any_lookup]   10k iterations took 55.04ms (avg 5.50us per matches_any lookup without cache)
[enum_iteration]                1M enum-iterations took 3458.80ms  (avg 3.46us per enum-iterations)
[convert_list]                  1M list-conversions took 3217.21ms (avg 3.22us per list-conversion)

## After speedup (Python 3.12.11, M4 Macbook Air):
[from_str_lookup]               1M iterations took 158.65ms (avg 0.16us per from_str lookup)
[no_cache_from_str_lookup]      10k iterations took 3.55ms  (avg 0.36us per from_str lookup without cache)
[matches_any_lookup]            1M iterations took 212.31ms (avg 0.21us per matches_any lookup)
[no_cache_matches_any_lookup]   10k iterations took 7.58ms  (avg 0.76us per matches_any lookup without cache)
[enum_iteration]                1M enum-iterations took 2263.28ms  (avg 2.26us per enum-iterations)
[convert_list]                  1M list-conversions took 1283.08ms (avg 1.28us per list-conversion)